### PR TITLE
Add: precommit CI bot config to repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,12 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
+
+ci:
+  # This ensures that pr's aren't autofixed by the bot, rather you call
+  # the bot to make the fix
+  autofix_prs: false
+  autofix_commit_msg: |
+    '[pre-commit.ci 🤖] Apply code format tools to PR'
+  # Update hook versions every month (so we don't get hit with weekly update pr's)
+  autoupdate_schedule: monthly

--- a/README.md
+++ b/README.md
@@ -52,3 +52,15 @@ We use `pre-commit` to ensure the code style is consistent. To install pre-commi
 Once you have `pre-commit` installed, the code stylers and linters
 defined in the `pre-commit-config.yaml` will run each time you
 commit modified changes to git locally.
+
+### Precommit.ci Bot
+
+We use the pre-commit CI bot to run linting tests and to auto fix
+pull requests. How it works:
+
+- Pre-commit.ci will run the CI checks via a CI run in the PR.
+- After the PR is approved but before it's merged, a maintainer can run the bot to apply linting fixes via a commit to the PR. To run the bot write:
+
+`pre-commit.ci autofix` in a comment in the PR. This will trigger another CI run to double check that the linting / code style fixes are as expected. Then you can merge!
+
+NOTE: the pre-commit CI bot CI action will allow you to see what checks pass. It will also remind you of the command to autofix the code in the pr.


### PR DESCRIPTION
closes #14 
Hi y'all! i've updated the config yaml to support the pre-commit ci bot. Someone with maintainer priveledges to the organization will need to approve the bot for use in this org.

to do that please

1. [go here](https://pre-commit.ci/) to the pre-commit.ci home page
2. sign in to github
3. Add the bot to the scientific-python organization
4. give the bot permissions to access / run on this repo. 
The bot will initially be confused if there is no config for it in the main branch. So we will have to merge this PR for it to be less confused :) 

I am happy to sit with someone to set this up while here at the summit!! it's super fast and once it's setup you can update the config.yaml file as needed to adjust tools and such that you want the bot to run. 

NOTE: the bot WILL look across the entire repo when it runs on a PR. but once the repo has been styled and linted, it will only modify the files submitted in a PR because the other files are already cleaned up. This bot is a great way to support drive-by contributors who don't want to mess with setting up pre-commit hooks locally (they can confuse people!)