### PR TITLE
Update README && fix devstats.scientific-python.org build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,7 @@ jobs:
             # NOTE: bad interaction w/ blas multithreading on circleci
             export OMP_NUM_THREADS=1
             source venv/bin/activate
-            cd devstats.scientific-python.org
-            git submodule update --init
-            make html
+            (cd devstats.scientific-python.org && make html)
 
       - store_artifacts:
           path: devstats.scientific-python.org/_build/html

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ This repository holds the `devstats` package. `devstats` is a Python command lin
 generate developer statistics and a developer statistics report for a specified
 project.
 
+## Data bundles & reports
+
+We make [regular data-bundle releases](https://github.com/scientific-python/devstats-data/releases) for several key scientific Python projects.
+
+We also build reports for this data, available at https://devstats.scientific-python.org
+
 ## OAuth key for accessing GitHub
 
 Per the [GitHub GraphQL API docs](https://developer.github.com/v4/guides/forming-calls/),


### PR DESCRIPTION
The website rebuild should now be done after the weekly data bundle artifact has been created, and should happen on the devstats.scientific-python.org repo.