### PR TITLE
Don't display np.int64(...) when displaying pony factor

### DIFF
--- a/devstats/reports/prs_pony_factor.md
+++ b/devstats/reports/prs_pony_factor.md
@@ -46,7 +46,7 @@ ax.hlines(
 )
 ax.legend();
 
-glue("{{ project }}_pony_factor", pony_factor)
+glue("{{ project }}_pony_factor", str(pony_factor))
 ```
 
 % TODO: Add:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/edb1eb12-4c7f-45ab-8462-7efe296311a8)
I noticed the formatting of the pony factor is a bit ugly in the above, hopefully this PR fixes that!