### PR TITLE
record the repo and repo owner

### DIFF
--- a/devstats/__main__.py
+++ b/devstats/__main__.py
@@ -108,6 +108,8 @@ def query(repo_owner, repo_name, outdir, start_date):
 
     with open(f"{outdir}/{repo_name}_misc.json", "w") as outf:
         misc_data = {}
+        misc_data["repo_owner"] = repo_owner
+        misc_data["repo_name"] = repo_name
         misc_data["query_start_date"] = start_date
         misc_data["query_end_date"] = str(datetime.datetime.now())
         misc_data["repo_stars"] = [


### PR DESCRIPTION
Towards https://github.com/scientific-python/devstats.scientific-python.org/issues/34

In the above issue it's requested to add a link to the actual repo. In order to do this we need to record who the repo owner is.